### PR TITLE
More idomatic error handling

### DIFF
--- a/server/src/main/scala/doodlebot/endpoint/chat.scala
+++ b/server/src/main/scala/doodlebot/endpoint/chat.scala
@@ -1,8 +1,6 @@
 package doodlebot
 package endpoint
 
-import cats.data.Xor
-import cats.syntax.xor._
 import io.finch._
 import com.twitter.util.Base64StringEncoder
 import doodlebot.action.Store
@@ -43,16 +41,14 @@ object Chat {
         NotAcceptable(BasicAuthFailed)
     }
 
-  val message: Endpoint[FormErrors Xor Unit] =
+  val message: Endpoint[Unit] =
     post("message" :: authorized :: param("name") :: param("message")) { (name: String, message: String) =>
       val msg = model.Message(name, message)
-      Store.message(msg)
-      Ok(().right[FormErrors])
+      Ok(Store.message(msg))
     }
 
-  val poll: Endpoint[FormErrors Xor Log] =
+  val poll: Endpoint[Log] =
     post("poll" :: authorized :: param("offset").as[Int]) { (offset: Int) =>
-      val log = Store.poll(offset)
-      Ok(log.right[FormErrors])
+      Ok(Store.poll(offset))
     }
 }

--- a/server/src/main/scala/doodlebot/endpoint/login.scala
+++ b/server/src/main/scala/doodlebot/endpoint/login.scala
@@ -12,7 +12,7 @@ import doodlebot.validation.InputError
 object Login {
   import doodlebot.model._
 
-  val login: Endpoint[FormErrors Xor Authenticated] = post("login" :: param("name") :: param("password")) { (name: String, password: String) =>
+  val login: Endpoint[Authenticated] = post("login" :: param("name") :: param("password")) { (name: String, password: String) =>
     val login = model.Login(Name(name), Password(password))
     val result: Xor[FormErrors,Authenticated] =
       Store.login(login).fold(
@@ -34,6 +34,6 @@ object Login {
         }
       )
 
-    Ok(result)
+    result.fold(BadRequest, Ok)
   }
 }

--- a/server/src/main/scala/doodlebot/endpoint/signup.scala
+++ b/server/src/main/scala/doodlebot/endpoint/signup.scala
@@ -13,7 +13,7 @@ import doodlebot.validation.InputError
 object Signup {
   import model._
 
-  val signup: Endpoint[FormErrors Xor Authenticated] =
+  val signup: Endpoint[Authenticated] =
     post("signup" :: param("name") :: param("email") :: param("password")) { (name: String, email: String, password: String) =>
       import doodlebot.syntax.validation._
 
@@ -46,6 +46,6 @@ object Signup {
           )
         }
 
-      Ok(result)
+      result.fold(BadRequest, Ok)
     }
 }

--- a/server/src/main/scala/doodlebot/endpoint/static.scala
+++ b/server/src/main/scala/doodlebot/endpoint/static.scala
@@ -1,8 +1,8 @@
 package doodlebot
 package endpoint
 
-import com.twitter.io.Reader
 import io.finch._
+import com.twitter.io.Reader
 import com.twitter.finagle.http.Response
 
 object Static {

--- a/server/src/main/scala/doodlebot/model.scala
+++ b/server/src/main/scala/doodlebot/model.scala
@@ -14,7 +14,7 @@ object model {
   final case class Authenticated(name: String, session: String)
   final case class Log(offset: Int, messages: List[Message])
   final case class Message(author: String, message: String)
-  final case class FormErrors(errors: InputError)
+  final case class FormErrors(errors: InputError) extends Exception
 
   // Messages from the client
   final case class Login(name: Name, password: Password)

--- a/server/src/main/scala/doodlebot/server.scala
+++ b/server/src/main/scala/doodlebot/server.scala
@@ -1,19 +1,25 @@
 package doodlebot
 
-import cats.data.Xor
 import com.twitter.finagle.Http
-import io.circe.Encoder
+import io.circe._
+import io.circe.syntax._
 import io.circe.generic.auto._
+import io.finch._
 import io.finch.circe._
 
 object DoodleBot {
   import doodlebot.endpoint._
+  import doodlebot.model.FormErrors
+
+  implicit val encodeException: Encoder[Exception] = Encoder.instance {
+    case fe @ FormErrors(_) => fe.asJson
+    case e => Json.obj(
+      "message" -> Json.fromString(s"""Exception was thrown: ${e.getMessage}""")
+    )
+  }
 
   val service =
     Static.static :+: Signup.signup :+: Login.login :+: Chat.message :+: Chat.poll
-
-  implicit def xorEncoder[A: Encoder,B: Encoder]: Encoder[Xor[A,B]] =
-    Encoder.encodeXor("error", "success")
 
   val server = {
     import doodlebot.model._
@@ -21,7 +27,7 @@ object DoodleBot {
     Store.signup(
       User(Name("tester"), Email("tester@example.com"), Password("password"))
     )
-    Http.serve(":8080", service.toService)
+    Http.serve(":8080", service.toServiceAs[Application.Json])
   }
 
 }


### PR DESCRIPTION
This PR introduces a couple of changes to make error handling more idiomatic to Finch:
1. `FormErrors` now extends `Exception` so we can wrap it with `Output.failure`
2. We now provide `io.circe.Encoder[Exception]` that uses Circe's generic derivation for `FormParams` and falls back to a simple `Json.obj` encoding.
3. All endpoints now return `A`, not `A Xor FormErrors` so we fold underlying `Xor`s.
4. On a client we now handle both cases: success (HTTP 200) and error (anything else).
